### PR TITLE
Logs to logstash

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,12 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <configuration>
-  <appender name="stash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-    <destination>logstash:5000</destination>
+  <springProfile name="minikube">
+    <appender name="stash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+      <destination>logstash:5000</destination>
 
-    <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-  </appender>
+      <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
 
-  <root level="INFO">
-    <appender-ref ref="stash" />
-  </root>
+    <root level="INFO">
+      <appender-ref ref="stash"/>
+    </root>
+  </springProfile>
+  <springProfile name="!minikube">
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <logger name="org.springframework.web" level="INFO"/>
+  </springProfile>
 </configuration>
+

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="stash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+    <destination>logstash:5000</destination>
+
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="stash" />
+  </root>
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <configuration>
-  <springProfile name="minikube">
+  <springProfile name="kube">
     <appender name="stash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
       <destination>logstash:5000</destination>
 
@@ -12,7 +12,7 @@
       <appender-ref ref="stash"/>
     </root>
   </springProfile>
-  <springProfile name="!minikube">
+  <springProfile name="!kube">
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
     <logger name="org.springframework.web" level="INFO"/>
   </springProfile>


### PR DESCRIPTION
We need to figure out to the side effects of this merge:
_we won't see the logs on the kubernetes dashboard anymore but only on the kibana ui.
_the format will be json

We will probably need a spring boot profile
to indicate which logback file to use.

If locally we don't need json format and we don't need elk

If we are using docker compose, do we need elk?

If minikube, then yes we need elk.

Do we want to introduce spring boot profiles specifying environments such as local, minikube, kube, docker-compose etc? Or we want to go more fine-grained and use profiles such as elk, zipkin, h2 to specify that this application needs to start with certain features/configs?
