### PR TITLE
update org.activiti.cloud.dependencies:activiti-cloud-dependencies to 7.0.138

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <activiti-cloud-dependencies.version>7.0.137</activiti-cloud-dependencies.version>
+    <activiti-cloud-dependencies.version>7.0.138</activiti-cloud-dependencies.version>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-failsafe-plugin.version>2.18.1</maven-failsafe-plugin.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version> <!-- required for jx -->


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.dependencies:activiti-cloud-dependencies` to: `7.0.138`