### PR TITLE
refactor(build): removed component scans from configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,10 +47,6 @@
       <artifactId>activiti-cloud-starter-audit</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.activiti.cloud.common</groupId>
-      <artifactId>activiti-cloud-services-common-security-keycloak</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>


### PR DESCRIPTION
This PR fixes Spring Boot bean override problems by removing component scans from configuration classes and adds missing @ConditionalOnMissingBean annotation on beans created in Activiti Runtime Spring Boot Auto-configurations

Depends on https://github.com/Activiti/activiti-cloud-audit-service/pull/233

Fixes https://github.com/Activiti/Activiti/issues/1399